### PR TITLE
fix: Fix lowResHeight computation

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -401,7 +401,7 @@ export function transformProps<
   // Auto-generate a low-res image for blurred placeholders
   if (transformer && background === "auto") {
     const lowResHeight = aspectRatio
-      ? Math.round(LOW_RES_WIDTH * aspectRatio)
+      ? Math.round(LOW_RES_WIDTH / aspectRatio)
       : undefined;
     const lowResImage = transformer({
       url,


### PR DESCRIPTION
Fixing a small issue regarding lowResHeight computation for auto background with aspect ratio.

Related to [#279](https://github.com/ascorbic/unpic-img/issues/279)